### PR TITLE
fix: fix invalid packets order check in sonar (position_look should b…

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -65,6 +65,10 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     time: 0,
     flags: { onGround: false, hasHorizontalCollision: false }
   }
+  const lastUpdated = {
+    yaw: 0,
+    pitch: 0
+  }
 
   // This function should be executed each tick (every 0.05 seconds)
   // How it works: https://gafferongames.com/post/fix_your_timestep/
@@ -196,7 +200,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
       // Send a position update every second, even if no other update was made
       // This function rounds to the nearest 50ms (or PHYSICS_INTERVAL_MS) and checks if a second has passed.
       (Math.round((now - lastSent.time) / PHYSICS_INTERVAL_MS) * PHYSICS_INTERVAL_MS) >= 1000
-    const lookUpdated = lastSent.yaw !== yaw || lastSent.pitch !== pitch
+    const lookUpdated = lastUpdated.yaw !== yaw || lastUpdated.pitch !== pitch
 
     if (positionUpdated && lookUpdated) {
       sendPacketPositionAndLook(position, yaw, pitch, onGround)
@@ -216,12 +220,17 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
       })
     }
 
+    if (lookUpdated) {
+      lastUpdated.yaw = yaw
+      lastUpdated.pitch = pitch
+    }
+
     lastSent.onGround = bot.entity.onGround // onGround is always set
+    bot.physicsEngineCtx = ectx
   }
 
   bot.physicsEngine = physics
   bot.physicsSettings = settings
-  bot.physicsCtx = ectx
   
   
   // Gen here, I'm about to do something very, very stupid. 


### PR DESCRIPTION
…e sent twice)

in original vanilla client last rot (xy) sets it only on client-side updating:
https://github.com/extremeheat/extracted_minecraft_data/blob/f984d21cbfd46ef77d36d0998e846e778a70c409/client/net/minecraft/client/player/LocalPlayer.java#L258

**But not** when `position` packet is received (no last xy rot update):
https://github.com/extremeheat/extracted_minecraft_data/blob/1ee826cddf592ea5de7214dff2f461a97153c8c7/client/net/minecraft/client/multiplayer/ClientPacketListener.java#L708

TODO also send position_look on vehicle remove (not that important for now)
https://github.com/extremeheat/extracted_minecraft_data/blob/1ee826cddf592ea5de7214dff2f461a97153c8c7/client/net/minecraft/client/multiplayer/ClientPacketListener.java#L593
