### PR TITLE
ray raycast block

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -8,6 +8,13 @@ const PLAYER_WIDTH = 0.6
 const PLAYER_EYEHEIGHT = 1.62
 const CROUCH_EYEHEIGHT = 1.27
 
+// export constants for reuse
+module.exports.PLAYER_HEIGHT = PLAYER_HEIGHT
+module.exports.CROUCH_HEIGHT = CROUCH_HEIGHT
+module.exports.PLAYER_WIDTH = PLAYER_WIDTH
+module.exports.PLAYER_EYEHEIGHT = PLAYER_EYEHEIGHT
+module.exports.CROUCH_EYEHEIGHT = CROUCH_EYEHEIGHT
+
 module.exports = inject
 
 const animationEvents = {

--- a/lib/plugins/ray_trace.js
+++ b/lib/plugins/ray_trace.js
@@ -1,5 +1,6 @@
 const { Vec3 } = require('vec3')
 const { RaycastIterator } = require('prismarine-world').iterators
+const { PLAYER_EYEHEIGHT, CROUCH_EYEHEIGHT } = require('./entities')
 
 module.exports = (bot) => {
   function getViewDirection (pitch, yaw) {
@@ -56,10 +57,12 @@ module.exports = (bot) => {
   }
 
   bot.blockAtEntityCursor = (entity = bot.entity, maxDistance = 256, matcher = null) => {
-    if (!entity.position || !entity.height || !entity.pitch || !entity.yaw) return null
-    const { position, height, pitch, yaw } = entity
+    if (!entity.position || !entity.height || entity.pitch === undefined || entity.yaw === undefined) return null
+    const { position, pitch, yaw } = entity
 
-    const eyePosition = position.offset(0, height, 0)
+    const eyeHeight = bot.controlState.sneak ? CROUCH_EYEHEIGHT : PLAYER_EYEHEIGHT
+
+    const eyePosition = position.offset(0, eyeHeight, 0)
     const viewDirection = getViewDirection(pitch, yaw)
 
     return bot.world.raycast(eyePosition, viewDirection, maxDistance, matcher)


### PR DESCRIPTION
right now bot.entity.height is not valid since server-side value is used
Instead it **should always be computed client-side** eg, wether shift is pressed or not.
issue is here: https://github.com/GenerelSchwerz/mineflayer/blob/ad366128475722e592b27b7e171f06dbf20679e6/lib/plugins/entities.js#L489

@GenerelSchwerz you can reproduce current issue by crouching and looking at cursor block on the web client on different angles (you will notice de-sync since camera is updated immediately)

I'm not fixing raycast entity for now as it seems to be a little more complicated (I'm using my own impl from mineflayer-mouse for now).